### PR TITLE
Keyboard shortcuts to select/switch tab

### DIFF
--- a/Tab Manager/Tab.js
+++ b/Tab Manager/Tab.js
@@ -13,6 +13,7 @@ function Tab(t,w){
 	if(This.Window.TabManager.Layout == "vertical"){
 		This.style.paddingLeft = "20px";
 		This.appendChild(Div("tabtitle",This.title));
+		This.appendChild(Div("tabselectnum",This.title));
 	}
 	if(t.incognito){
 		This.addClass("incognito");

--- a/Tab Manager/TabManager.js
+++ b/Tab Manager/TabManager.js
@@ -123,6 +123,15 @@ function TabManager(){
 					});
 				}
 			});
+
+			function refreshTabSelectNums(){
+				var tabs = This.getElementsByClassName("tab selected");
+				for(var i = 0; i < tabs.length && i < 9; i++){
+					tab = tabs[i];
+					var tabselectnum= tab.getElementsByClassName("tabselectnum")[0];
+					tabselectnum.innerHTML = i + 1;
+				}
+			}
 			
 			search.on("keyup",function(){
 				var tabs = This.getElementsByClassName("tab");
@@ -132,14 +141,30 @@ function TabManager(){
 						tab.addClass("selected");
 					}else{
 						tab.removeClass("selected");
+						tab.getElementsByClassName("tabselectnum")[0].innerHTML = "";
 					}
 				}
+				refreshTabSelectNums();
 			});
 			search.on("keydown",function(e){
 				console.log(e.keyCode);
 				if(e.keyCode == 13){
 					addWindow();
-				}					
+				}else{
+					var tabs = This.getElementsByClassName("tab selected");
+					var tabNum = e.keyCode - 49;
+					if(tabNum >= 0 && tabNum < tabs.length && tabNum < 9){
+						chrome.tabs.update(tabs[tabNum].ID,{selected:true});
+					}
+				}
+			});
+			search.on("blur",function(){
+				tabs = This.getElementsByClassName("tab");
+				for(var i = 0; i < tabs.length; i++){
+					tab = tabs[i];
+					var tabselectnum = tab.getElementsByClassName("tabselectnum")[0];
+					tabselectnum.innerHTML = "";
+				}
 			});
 			
 			layout.on("click",function(){

--- a/Tab Manager/TabManager.js
+++ b/Tab Manager/TabManager.js
@@ -130,6 +130,7 @@ function TabManager(){
 					tab = tabs[i];
 					var tabselectnum= tab.getElementsByClassName("tabselectnum")[0];
 					tabselectnum.innerHTML = i + 1;
+					tabselectnum.style.backgroundColor = "#3B5686";
 				}
 			}
 			
@@ -141,7 +142,9 @@ function TabManager(){
 						tab.addClass("selected");
 					}else{
 						tab.removeClass("selected");
-						tab.getElementsByClassName("tabselectnum")[0].innerHTML = "";
+						var tabselectnum = tab.getElementsByClassName("tabselectnum")[0];
+						tabselectnum.innerHTML = "";
+						tabselectnum.style.backgroundColor = "";
 					}
 				}
 				refreshTabSelectNums();
@@ -164,6 +167,7 @@ function TabManager(){
 					tab = tabs[i];
 					var tabselectnum = tab.getElementsByClassName("tabselectnum")[0];
 					tabselectnum.innerHTML = "";
+					tabselectnum.style.backgroundColor = "";
 				}
 			});
 			

--- a/Tab Manager/TabManager.js
+++ b/Tab Manager/TabManager.js
@@ -158,6 +158,7 @@ function TabManager(){
 					var tabNum = e.keyCode - 49;
 					if(tabNum >= 0 && tabNum < tabs.length && tabNum < 9){
 						chrome.tabs.update(tabs[tabNum].ID,{selected:true});
+						window.close();
 					}
 				}
 			});

--- a/Tab Manager/popup.css
+++ b/Tab Manager/popup.css
@@ -71,10 +71,18 @@ body{
 	background-position:2px center;
 }
 .tab.full > .tabtitle{
+	float:left;
 	width:310px;
 	height:100%;
 	white-space:nowrap;
 	overflow:hidden;
+}
+.tab.full > .tabselectnum{
+	float:right;
+	margin-right:-16px;
+	color:#3B5686;
+	width:10px;
+	height:100%;
 }
 .tab:first-child, .newliner + .icon{
 	margin-left:0px;

--- a/Tab Manager/popup.css
+++ b/Tab Manager/popup.css
@@ -76,14 +76,19 @@ body{
 	height:100%;
 	white-space:nowrap;
 	overflow:hidden;
+	text-overflow:ellipsis;
 }
 .tab.full > .tabselectnum{
 	float:right;
-	margin-right:-16px;
-	color:#3B5686;
-	width:10px;
-	height:100%;
+	margin-right:-46px;
+	margin-top:-2px;
+	padding-left:26px;
+	padding-top: 2px;
+	color:white;
+	width:20px;
+	height:18px;
 }
+
 .tab:first-child, .newliner + .icon{
 	margin-left:0px;
 }		

--- a/Tab Manager/popup.css
+++ b/Tab Manager/popup.css
@@ -80,12 +80,12 @@ body{
 }
 .tab.full > .tabselectnum{
 	float:right;
-	margin-right:-46px;
+	margin-right:-18px;
 	margin-top:-2px;
-	padding-left:26px;
+	padding-left:6px;
 	padding-top: 2px;
 	color:white;
-	width:20px;
+	width:12px;
 	height:18px;
 }
 


### PR DESCRIPTION
Hi Patrik

Thanks for your extension. I like it but wanted to be able to select a tab entirely with the keyboard so wrote this code if you want to use it. 

The addition numbers the search matches when using the search input and the desired tab can be immediately switched to by hitting its number key instead of using the mouse.

For anyone wanting to use this I recommend setting up a keyboard shortcut in the extensions page to open Tab Manager too (As @denilsonsa described: Go to Settings → Extensions → Scroll to the bottom → Configure commands)
I use Ctrl-Q as the release of Ctrl key causes all tabs to be selected and numbered and this aligns well with Chrome's built in tab switching shortcuts (ctrl + number key).

Re Issue #16