### PR TITLE
changed Ctrl+M to Alt+M.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,7 @@
     "commands": {
         "_execute_browser_action": {
             "suggested_key": {
-                "default":"Ctrl+M"
+                "default":"Option+Ctrl+M" || "Alt+Ctrl+M"
             }
         }
      }

--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,7 @@
     "commands": {
         "_execute_browser_action": {
             "suggested_key": {
-                "default":"Option+Ctrl+M" || "Alt+Ctrl+M"
+                "default":"Alt+M"
             }
         }
      }


### PR DESCRIPTION
changed Ctrl+M to Alt+M to allow OSX users to use global hotkey to minimize windows.

relates to issue #41 